### PR TITLE
change the initial FE name

### DIFF
--- a/packages/core/src/state/user/reducer.ts
+++ b/packages/core/src/state/user/reducer.ts
@@ -57,7 +57,7 @@ export const initialState: UserState = {
   depositWithdrawalsData: null,
   depositWithdrawalsState: ApiState.LOADING,
   isTermsAccepted: TermsStatus.NOT_ACCEPTED,
-  frontEndName: "Cloverfield",
+  frontEndName: "Alpha", //TODO revert to Cloverfield once it is integrated
 };
 
 export default createReducer(initialState, (builder) =>


### PR DESCRIPTION
- Problem: the initial email is set to unknown FE name in the SDK version we use.
- Solution: change the initial FE name to Alpha since BSC chain info in the SDK version we have returns only Alpha FE contract info.
- TODO: rollback the change once "Cloverfield" (initial FE name in the current SDK)